### PR TITLE
feat: adding ARM64 to existing build-arch

### DIFF
--- a/build/make.go
+++ b/build/make.go
@@ -32,6 +32,7 @@ const (
 	GOOS              = "GOOS"
 	X86               = "386"
 	X86_64            = "amd64"
+	ARM64             = "arm64"
 	DARWIN            = "darwin"
 	LINUX             = "linux"
 	WINDOWS           = "windows"
@@ -295,10 +296,11 @@ var binDir = flag.String("bin-dir", "", "Specifies OS_PLATFORM specific binaries
 
 var (
 	platformEnvs = []map[string]string{
-		map[string]string{GOARCH: X86, GOOS: DARWIN, CGO_ENABLED: "0"},
+		map[string]string{GOARCH: ARM64, GOOS: DARWIN, CGO_ENABLED: "0"},
 		map[string]string{GOARCH: X86_64, GOOS: DARWIN, CGO_ENABLED: "0"},
 		map[string]string{GOARCH: X86, GOOS: LINUX, CGO_ENABLED: "0"},
 		map[string]string{GOARCH: X86_64, GOOS: LINUX, CGO_ENABLED: "0"},
+		map[string]string{GOARCH: ARM64, GOOS: LINUX, CGO_ENABLED: "0"},
 		map[string]string{GOARCH: X86, GOOS: WINDOWS, CGO_ENABLED: "0"},
 		map[string]string{GOARCH: X86_64, GOOS: WINDOWS, CGO_ENABLED: "0"},
 	}


### PR DESCRIPTION
## Scope 

This PR introduces ARM64 to the list of available build-architectures similar to e.g. the html report. 
A potential new version (0.2.4) is already bumped on master, though not released - I don't know how you normally handle it :) 

closes #42 

## Acceptance Criteria

 - [x] Build works on host-machine
```
> go run build/make.go --all-platforms
Compiling for platform => OS:darwin ARCH:arm64 
2022/08/24 08:58:35 Execute [go build -o bin/darwin_arm64/xml-report]
Compiling for platform => OS:darwin ARCH:amd64 
2022/08/24 08:58:46 Execute [go build -o bin/darwin_amd64/xml-report]
Compiling for platform => OS:linux ARCH:386 
2022/08/24 08:58:50 Execute [go build -o bin/linux_386/xml-report]
go: downloading golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
Compiling for platform => OS:linux ARCH:amd64 
2022/08/24 08:59:00 Execute [go build -o bin/linux_amd64/xml-report]
Compiling for platform => OS:linux ARCH:arm64 
2022/08/24 08:59:09 Execute [go build -o bin/linux_arm64/xml-report]
Compiling for platform => OS:windows ARCH:386 
2022/08/24 08:59:16 Execute [go build -o bin/windows_386/xml-report.exe]
Compiling for platform => OS:windows ARCH:amd64 
2022/08/24 08:59:23 Execute [go build -o bin/windows_amd64/xml-report.exe]
```
 - [x] Plugin can be installed (open)
 - [x] Runs on server (open)

Signed-off-by: Matthias Holetzko <mholetzko@gmx.net>