### PR TITLE
fix: Generate xml report with Table driven scenarios

### DIFF
--- a/builder/xmlReportBuilder.go
+++ b/builder/xmlReportBuilder.go
@@ -197,7 +197,7 @@ func (x *XmlBuilder) getScenarioContent(result *gauge_messages.ProtoSpecResult, 
 func (x *XmlBuilder) getTableDrivenScenarioContent(result *gauge_messages.ProtoSpecResult, tableDriven *gauge_messages.ProtoTableDrivenScenario, ts *JUnitTestSuite) {
 	if tableDriven.GetScenario() != nil {
 		scenario := tableDriven.GetScenario()
-		scenario.ScenarioHeading += " " + strconv.Itoa(int(tableDriven.GetTableRowIndex())+1)
+		scenario.ScenarioHeading += " " + strconv.Itoa(int(tableDriven.GetScenarioTableRowIndex())+1)
 		x.getScenarioContent(result, scenario, ts)
 	}
 }


### PR DESCRIPTION
In 0.5.0 version xml-report
Test suite name is derived from Table driven scenario always append only 1
Because GetTableRowIndex() is for table driven step. 

I think TableDrivenScenarioContent might call GetScenarioTableRowIndex