### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -28,5 +28,5 @@
     "scope": [
         "Execution"
     ],
-    "version": "0.5.4"
+    "version": "1.0.0"
 }


### PR DESCRIPTION
Easier to convey future breaking changes and better conveys plugin stability.